### PR TITLE
Create Makefile to manage URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+CADDY_ADMIN_API=http://127.0.0.1:2019
+APP_URL=https://example.org

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ fly
 fly-cert.pub
 cert.pem
 key.pem
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM caddy:2.7.6-alpine
 
-RUN apk add bash --no-cache
+RUN apk add bash curl --no-cache
 
 COPY ./conf/caddy-config-loader.json /etc/caddy/caddy-config-loader.json
 COPY ./docker/start.sh /start.sh

--- a/Makefile
+++ b/Makefile
@@ -37,19 +37,19 @@ endif
 	@echo "Deleting route with ID $(id)"
 	@flyctl ssh console --command "curl -X DELETE -H 'Content-Type: application/json' $(CADDY_ADMIN_API)/id/$(id)"
 
-.PHONY: restart
+.PHONY: restart # Restart the app
 restart:
 	@flyctl apps restart
 
-.PHONY: reload
+.PHONY: reload # Gracefully shut down the server and exit the process, which will restart automatically
 reload:
 	@flyctl ssh console --command "curl -X POST $(CADDY_ADMIN_API)/stop"
 
-.PHONY: print_config
+.PHONY: print_config # Print the Caddy configuration
 print_config:
 	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)/config/" | jq
 
-.PHONY: print_routes
+.PHONY: print_routes # Print the list of routes (JSON, CSV or table format)
 print_routes:
 ifndef output_format
 	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)" | jq

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,14 @@ endif
 	@flyctl ssh console --command "curl -X PUT -H 'Content-Type: application/json' -d '{\"@id\":\"$(encoded_title)\",\"input\":\"/$(shortcode)\",\"outputs\":[\"$(url)\"]}' http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings/0"
 	@echo "https://actes.williamblondel.fr/$(shortcode)"
 
+.PHONY: delete # Delete a URL by ID
+delete:
+ifndef id
+	$(error id is undefined)
+endif
+	@echo "Deleting route with ID $(id)"
+	@flyctl ssh console --command "curl -X DELETE -H 'Content-Type: application/json' http://127.0.0.1:2019/id/$(id)"
+
 .PHONY: restart
 restart:
 	@flyctl apps restart

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+.DEFAULT_GOAL := help
+
+# Function to encode a string to base64url
+base64url_encode = $(shell printf '%s' '$1' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
+
+.PHONY: all
+all:
+
+.PHONY: short # Shorten a URL
+short:
+ifndef url
+	$(error url is undefined)
+endif
+ifndef shortcode
+	$(eval shortcode := $(shell dd if=/dev/urandom bs=4 count=2 2>/dev/null | xxd -p -c 4 | tr -dc 'a-zA-Z0-9' | head -c 8))
+endif
+ifndef title
+	$(error title is undefined)
+endif
+	$(eval encoded_title := $(call base64url_encode,$(title)))
+
+	@echo "Shortcode: $(shortcode)..."
+	@echo "Encoded title: $(encoded_title)"
+	@flyctl ssh console --command "curl -X PUT -H 'Content-Type: application/json' -d '{\"@id\":\"$(encoded_title)\",\"input\":\"/$(shortcode)\",\"outputs\":[\"$(url)\"]}' http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings/0"
+	@echo "https://actes.williamblondel.fr/$(shortcode)"
+
+.PHONY: restart
+restart:
+	@flyctl apps restart
+
+.PHONY: reload
+reload:
+	@flyctl ssh console --command "curl -X POST http://localhost:2019/stop"
+
+.PHONY: print_config
+print_config:
+	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config" | jq
+
+.PHONY: print_routes
+print_config:
+	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings" | jq
+
+.PHONY: help # List available commands
+help:
+	@echo "Available commands:"
+	@echo
+	@grep '^.PHONY: .* #' Makefile | sed 's/\.PHONY: \(.*\) # \(.*\)/\1 >> \2/' | expand -t20

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 .DEFAULT_GOAL := help
 
+MAPPINGS_ROUTE := "/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings"
+
+include .env
+export
+
 # Function to encode a string to base64url
 base64url_encode = $(shell printf '%s' '$1' | openssl base64 -e -A | tr '+/' '-_' | tr -d '=')
 
@@ -21,8 +26,8 @@ endif
 
 	@echo "Shortcode: $(shortcode)..."
 	@echo "Encoded title: $(encoded_title)"
-	@flyctl ssh console --command "curl -X PUT -H 'Content-Type: application/json' -d '{\"@id\":\"$(encoded_title)\",\"input\":\"/$(shortcode)\",\"outputs\":[\"$(url)\"]}' http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings/0"
-	@echo "https://actes.williamblondel.fr/$(shortcode)"
+	@flyctl ssh console --command "curl -X PUT -H 'Content-Type: application/json' -d '{\"@id\":\"$(encoded_title)\",\"input\":\"/$(shortcode)\",\"outputs\":[\"$(url)\"]}' $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)/0"
+	@echo "$(APP_URL)/$(shortcode)"
 
 .PHONY: delete # Delete a URL by ID
 delete:
@@ -30,7 +35,7 @@ ifndef id
 	$(error id is undefined)
 endif
 	@echo "Deleting route with ID $(id)"
-	@flyctl ssh console --command "curl -X DELETE -H 'Content-Type: application/json' http://127.0.0.1:2019/id/$(id)"
+	@flyctl ssh console --command "curl -X DELETE -H 'Content-Type: application/json' $(CADDY_ADMIN_API)/id/$(id)"
 
 .PHONY: restart
 restart:
@@ -38,15 +43,28 @@ restart:
 
 .PHONY: reload
 reload:
-	@flyctl ssh console --command "curl -X POST http://localhost:2019/stop"
+	@flyctl ssh console --command "curl -X POST $(CADDY_ADMIN_API)/stop"
 
 .PHONY: print_config
 print_config:
-	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config" | jq
+	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)/config/" | jq
 
 .PHONY: print_routes
 print_routes:
-	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings" | jq
+ifndef output_format
+	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)" | jq
+else
+ifeq ($(output_format),json)
+	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)" | jq
+else ifeq ($(output_format),table)
+	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)" | jq -r '["@id", "input", "outputs"], (.[] | [.["@id"], .input, .outputs[]]) | @tsv' | column -t
+else ifeq ($(output_format),csv)
+	@flyctl ssh console --quiet --command "curl -s $(CADDY_ADMIN_API)$(MAPPINGS_ROUTE)" | jq -r '["@id", "input", "outputs"], (.[] | [.["@id"], .input, .outputs[]]) | @csv'
+else
+	@echo "Invalid output format: $(output_format)"
+	@echo "Should be json or table"
+endif
+endif
 
 .PHONY: help # List available commands
 help:

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ print_config:
 	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config" | jq
 
 .PHONY: print_routes
-print_config:
+print_routes:
 	@flyctl ssh console --quiet --command "curl -s http://127.0.0.1:2019/config/apps/http/servers/srv0/routes/0/handle/0/routes/0/handle/0/mappings" | jq
 
 .PHONY: help # List available commands


### PR DESCRIPTION
I implemented the commands listed in #1:

- [x] Command to shorten a URL
  - [x] Requires a URL
  - [x] Accepts a shortcode, but generates an 8-character one if not provided
  - [x] Requires a title
  - [x] Encodes the title with [Base64URL](https://base64.guru/standards/base64url)
  - [x] Send a request to Caddy Admin to save the link
  - [x] Show the generated link
- [x] Command to delete a URL by ID (encoded title)
- [x] Command to show the current Caddy config (full config)
- [x] Command to show the list of URLs (partial config)
  - [x] As JSON
  - [x] As CSV
  - [x] As table 